### PR TITLE
fix a missing return

### DIFF
--- a/worker/dist/worker.js
+++ b/worker/dist/worker.js
@@ -700,7 +700,7 @@ ${fileht}
   addEventListener('fetch', event => {
     event.respondWith(handleRequest(event.request).catch(err => {
       console.error(err);
-      new Response(JSON.stringify(err.stack), {
+      return new Response(JSON.stringify(err.stack), {
         status: 500,
         headers: {
           'Content-Type': 'application/json'

--- a/worker/index.js
+++ b/worker/index.js
@@ -255,7 +255,7 @@ addEventListener('fetch', event => {
 	event.respondWith(
 		handleRequest(event.request).catch(err => {
 			console.error(err)
-			new Response(JSON.stringify(err.stack), {
+			return new Response(JSON.stringify(err.stack), {
 				status: 500,
 				headers: {
 					'Content-Type': 'application/json'


### PR DESCRIPTION
https://github.com/maple3142/GDIndex/blob/2d95552ed4d1f8d5955ee27738c845734649d1aa/worker/dist/worker.js#L703

Here a `return` is missing, and no error status will be returned.