### PR TITLE
Enable lite mode through HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ This mode will serve a simple nginx-like directory listing, and it only work wit
 
 On the top of the script, change `lite: false` into `lite: true`, than thats all.
 
-To enable on-the-fly lite mode, especially with command-line applications, you can include a HTTP header `lite: true` in your requests.
+To enable on-the-fly lite mode, especially with command-line applications, you can include a HTTP header `x-lite: true` in your requests.
 
 [Lite mode demo](https://gdindex-demo-lite.maple3142.workers.dev/)

--- a/README.md
+++ b/README.md
@@ -44,4 +44,6 @@ This mode will serve a simple nginx-like directory listing, and it only work wit
 
 On the top of the script, change `lite: false` into `lite: true`, than thats all.
 
+To enable on-the-fly lite mode, especially with command-line applications, you can include a HTTP header `lite: true` in your requests.
+
 [Lite mode demo](https://gdindex-demo-lite.maple3142.workers.dev/)

--- a/worker/dist/worker.js
+++ b/worker/dist/worker.js
@@ -642,7 +642,7 @@ self.props = {
     request.pathname = request.pathname.split('/').map(decodeURIComponent).map(decodeURIComponent) // for some super special cases, browser will force encode it...   eg: +αあるふぁきゅん。 - +♂.mp3
     .join('/');
 
-    if (self.props.lite && request.pathname.endsWith('/')) {
+    if ((self.props.lite || request.headers.get('lite') == "true") && request.pathname.endsWith('/')) {
       // lite mode
       const path = request.pathname;
       let parent = encodePathComponent(path.split('/').slice(0, -2).join('/') + '/');

--- a/worker/index.js
+++ b/worker/index.js
@@ -194,7 +194,7 @@ async function handleRequest(request) {
 		.join('/')
 
 	if (
-		(self.props.lite || request.headers.get('lite') == 'true') &&
+		(self.props.lite || request.headers.get('x-lite') == 'true') &&
 		request.pathname.endsWith('/')
 	) {
 		// lite mode

--- a/worker/index.js
+++ b/worker/index.js
@@ -193,7 +193,7 @@ async function handleRequest(request) {
 		.map(decodeURIComponent) // for some super special cases, browser will force encode it...   eg: +αあるふぁきゅん。 - +♂.mp3
 		.join('/')
 
-	if (self.props.lite && request.pathname.endsWith('/')) {
+	if ((self.props.lite || request.headers.get('lite') == "true") && request.pathname.endsWith('/')) {
 		// lite mode
 		const path = request.pathname
 		let parent = encodePathComponent(

--- a/worker/index.js
+++ b/worker/index.js
@@ -193,7 +193,10 @@ async function handleRequest(request) {
 		.map(decodeURIComponent) // for some super special cases, browser will force encode it...   eg: +αあるふぁきゅん。 - +♂.mp3
 		.join('/')
 
-	if ((self.props.lite || request.headers.get('lite') == "true") && request.pathname.endsWith('/')) {
+	if (
+		(self.props.lite || request.headers.get('lite') == 'true') &&
+		request.pathname.endsWith('/')
+	) {
 		// lite mode
 		const path = request.pathname
 		let parent = encodePathComponent(


### PR DESCRIPTION
This code change will allowing enabling of the lite mode through a HTTP header sent in the GET request. This allows programs like rclone to access the index, without having to enable lite-mode for the entire site on the server-side